### PR TITLE
Update 'response_waits' map.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,11 +1,12 @@
 use crate::{
+    completion_queue::WorkRequestId,
     memory_region::{
         Local, LocalMemoryRegion, MemoryRegion, MemoryRegionToken, RemoteMemoryRegion,
     },
     mr_allocator::MRAllocator,
     queue_pair::QueuePair,
 };
-use rand::Rng;
+use lockfree_cuckoohash::{pin, LockFreeCuckooHash};
 use serde::{Deserialize, Serialize};
 use std::{
     alloc::Layout,
@@ -18,13 +19,12 @@ use std::{
 use tokio::{
     sync::{
         mpsc::{channel, Receiver, Sender},
-        oneshot, Mutex,
+        Mutex,
     },
     task::JoinHandle,
 };
 use tracing::{debug, trace};
 use utilities::{Cast, OverflowArithmetic};
-
 /// An agent for handling the dirty rdma request and async events
 #[derive(Debug)]
 pub struct Agent {
@@ -53,7 +53,7 @@ impl Agent {
         allocator: Arc<MRAllocator>,
         max_message_len: usize,
     ) -> io::Result<Self> {
-        let response_waits = Arc::new(Mutex::new(HashMap::new()));
+        let response_waits = Arc::new(LockFreeCuckooHash::new());
         let mr_own = Arc::new(Mutex::new(HashMap::new()));
         let (mr_send, mr_recv) = channel(1024);
         let (data_send, data_recv) = channel(1024);
@@ -115,7 +115,7 @@ impl Agent {
             SendMRKind::Remote(mr.token())
         };
         let request = Request {
-            request_id: RequestId::new(),
+            request_id: WorkRequestId::new(),
             kind: RequestKind::SendMR(SendMRRequest { kind: request }),
         };
         // this response is not important
@@ -139,7 +139,7 @@ impl Agent {
         while start < lm_len {
             let end = (start.overflow_add(max_content_len)).min(lm_len);
             let request = Request {
-                request_id: RequestId::new(),
+                request_id: WorkRequestId::new(),
                 kind: RequestKind::SendData(SendDataRequest {
                     len: end.overflow_sub(start),
                 }),
@@ -347,12 +347,11 @@ impl AgentThread {
     /// response handler
     async fn handle_response(self: Arc<Self>, response: Response) -> io::Result<()> {
         trace!("handle response");
+        let guard = pin();
         let sender = self
             .inner
             .response_waits
-            .lock()
-            .await
-            .remove(&response.request_id)
+            .remove_with_guard(&response.request_id, &guard)
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::Other,
@@ -362,7 +361,7 @@ impl AgentThread {
                     ),
                 )
             })?;
-        match sender.send(Ok(response.kind)) {
+        match sender.try_send(Ok(response.kind)) {
             Ok(_) => Ok(()),
             Err(_) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -406,7 +405,7 @@ pub struct AgentInner {
     /// The Queue Pair used to communicate with other side
     qp: Arc<QueuePair>,
     /// The map holding the waiters that waits the response
-    response_waits: Arc<Mutex<ResponseWaitsMap>>,
+    response_waits: ResponseWaitsMap,
     /// The Mrs owned by this agent
     mr_own: Arc<Mutex<HashMap<MemoryRegionToken, Arc<LocalMemoryRegion>>>>,
     /// MR allocator that creating new memory regions
@@ -426,7 +425,7 @@ impl AgentInner {
             align: layout.align(),
         };
         let request = Request {
-            request_id: RequestId::new(),
+            request_id: WorkRequestId::new(),
             kind: RequestKind::AllocMR(request),
         };
         let response = self.send_request(request).await?;
@@ -446,7 +445,7 @@ impl AgentInner {
     /// Release a remote MR got from the other side
     pub async fn release_mr(&self, token: MemoryRegionToken) -> io::Result<()> {
         let request = Request {
-            request_id: RequestId::new(),
+            request_id: WorkRequestId::new(),
             kind: RequestKind::ReleaseMR(ReleaseMRRequest { token }),
         };
         let _response = self.send_request(request).await?;
@@ -461,16 +460,20 @@ impl AgentInner {
     /// Send a request with data appended
     async fn send_request_append_data(
         &self,
-        request: Request,
+        mut request: Request,
         lm: &[&LocalMemoryRegion],
     ) -> io::Result<ResponseKind> {
-        let (send, recv) = oneshot::channel();
+        let (tx, mut rx) = channel(2);
         // As request is always newly created, it's impossible to find it in the response_waits
-        let _old = self
-            .response_waits
-            .lock()
-            .await
-            .insert(request.request_id, send);
+        loop {
+            if self
+                .response_waits
+                .insert_if_not_exists(request.request_id, tx.clone())
+            {
+                break;
+            }
+            request.request_id = WorkRequestId::new();
+        }
 
         let mut buf = self
             .allocator
@@ -490,10 +493,9 @@ impl AgentInner {
         let lms_len: usize = lms.iter().map(|l| l.length()).sum();
         assert!(lms_len <= self.max_message_len);
         self.qp.send_sge(&lms).await?;
-        let ans = recv
+        rx.recv()
             .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-        ans
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "agent is dropped"))?
     }
 
     /// Send a response to the other side
@@ -519,7 +521,7 @@ impl AgentInner {
 lazy_static! {
     static ref SEND_DATA_OFFSET: usize = {
         let request = Request {
-            request_id: RequestId::new(),
+            request_id: WorkRequestId::new(),
             kind: RequestKind::SendData(SendDataRequest { len: 0 }),
         };
         let message = Message::Request(request);
@@ -530,18 +532,7 @@ lazy_static! {
 }
 
 /// The map for the task waiters, these tasks have submitted the RDMA request but haven't got the result
-type ResponseWaitsMap = HashMap<RequestId, oneshot::Sender<io::Result<ResponseKind>>>;
-
-/// The Id for each RDMA request
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Debug)]
-struct RequestId(usize);
-
-impl RequestId {
-    /// Randomly generate a request id
-    fn new() -> Self {
-        Self(rand::thread_rng().gen())
-    }
-}
+type ResponseWaitsMap = Arc<LockFreeCuckooHash<WorkRequestId, Sender<io::Result<ResponseKind>>>>;
 
 /// Request to alloc a remote MR
 #[derive(Serialize, Deserialize)]
@@ -624,7 +615,7 @@ enum RequestKind {
 #[derive(Serialize, Deserialize)]
 struct Request {
     /// Request id
-    request_id: RequestId,
+    request_id: WorkRequestId,
     /// The type of the request
     kind: RequestKind,
 }
@@ -646,7 +637,7 @@ enum ResponseKind {
 #[derive(Serialize, Deserialize)]
 struct Response {
     /// Request id
-    request_id: RequestId,
+    request_id: WorkRequestId,
     /// The type of the response
     kind: ResponseKind,
 }

--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -5,6 +5,7 @@ use rand::Rng;
 use rdma_sys::{
     ibv_cq, ibv_create_cq, ibv_destroy_cq, ibv_poll_cq, ibv_req_notify_cq, ibv_wc, ibv_wc_status,
 };
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::Debug,
     io, mem,
@@ -205,7 +206,7 @@ impl From<WCError> for io::Error {
 }
 
 /// Work request id
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct WorkRequestId(u64);
 
 impl WorkRequestId {


### PR DESCRIPTION
LockFreeCuckooHash is used to replace Hashmap and WorkRequestID is used to replace RequestID, ensuring the uniqueness of the ID used in each request and avoiding the crash that may be caused by ID duplication.