### PR TITLE
Update 'response_waits' map.

### DIFF
--- a/src/completion_queue.rs
+++ b/src/completion_queue.rs
@@ -1,19 +1,12 @@
-use crate::{context::Context, event_channel::EventChannel};
+use crate::{context::Context, event_channel::EventChannel, id};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use rand::Rng;
 use rdma_sys::{
     ibv_cq, ibv_create_cq, ibv_destroy_cq, ibv_poll_cq, ibv_req_notify_cq, ibv_wc, ibv_wc_status,
 };
-use std::{
-    fmt::Debug,
-    io, mem,
-    ops::Sub,
-    ptr::NonNull,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{fmt::Debug, io, mem, ops::Sub, ptr::NonNull};
 use thiserror::Error;
-use utilities::{Cast, OverflowArithmetic};
+use utilities::Cast;
 
 /// Complete Queue Structure
 #[derive(Debug)]
@@ -210,17 +203,9 @@ impl From<WCError> for io::Error {
 pub(crate) struct WorkRequestId(u64);
 
 impl WorkRequestId {
-    /// Creat a new work request id
+    /// Create a new id for `WorkRequest`
     pub(crate) fn new() -> Self {
-        let start = SystemTime::now();
-        // No time can be earlier than Unix Epoch
-        #[allow(clippy::unwrap_used)]
-        let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
-        let time = since_the_epoch.subsec_micros();
-        let rand = rand::thread_rng().gen::<u32>();
-        let left: u64 = time.into();
-        let right: u64 = rand.into();
-        Self(left.overflow_shl(32) | right)
+        WorkRequestId(id::random_u64())
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,20 @@
+use rand::Rng;
+use std::time::{SystemTime, UNIX_EPOCH};
+use utilities::OverflowArithmetic;
+
+/// Creat a random u64 id.
+///
+/// Both `WorkRequetId` and `AgentRequestId` depend on this, so make this fn independent.
+/// To avoid id duplication, this fn concatenates `SystemTime` and random number into a U64.
+/// The syscall may have some overhead, which can be improved later by balancing the pros and cons.
+pub(crate) fn random_u64() -> u64 {
+    let start = SystemTime::now();
+    // No time can be earlier than Unix Epoch
+    #[allow(clippy::unwrap_used)]
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
+    let time = since_the_epoch.subsec_micros();
+    let rand = rand::thread_rng().gen::<u32>();
+    let left: u64 = time.into();
+    let right: u64 = rand.into();
+    left.overflow_shl(32) | right
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ mod event_channel;
 mod event_listener;
 /// Gid for device
 mod gid;
+/// id utils
+mod id;
 /// Memory region abstraction
 mod memory_region;
 /// Memory window abstraction


### PR DESCRIPTION
LockFreeCuckooHash is used to replace Hashmap and WorkRequestID is used to replace RequestID, ensuring the uniqueness of the ID used in each request and avoiding the crash that may be caused by ID duplication.