### PR TITLE
add `LocalMrInner` and ensure cancellation safety

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.15", features = ["full", "tracing"]}
 tracing = "0.1"
 tracing-subscriber = "0.3.9"
 tikv-jemalloc-sys = "0.4.3"
-parking_lot = "0.12.0"
+parking_lot = {version = "0.12.0", features = ["arc_lock", "send_guard"]}
 
 [dev-dependencies]
 portpicker = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ parking_lot = {version = "0.12.0", features = ["arc_lock", "send_guard"]}
 [dev-dependencies]
 portpicker = "0.1.1"
 minstant = "0.1"
+
+[features]
+cancel_safety_test = [] # only used for cancel_safety test

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -15,21 +15,21 @@ use tracing::debug;
 
 async fn send_lmr_to_server(rdma: &Rdma) {
     let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-    unsafe { *(lmr.as_mut_ptr() as *mut char) = 'h' };
+    unsafe { *(*lmr.as_mut_ptr() as *mut char) = 'h' };
     rdma.send_local_mr(lmr).await.unwrap();
 }
 
 async fn request_then_write(rdma: &Rdma) {
     let mut rmr = rdma.request_remote_mr(Layout::new::<char>()).await.unwrap();
     let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-    unsafe { *(lmr.as_mut_ptr() as *mut char) = 'e' };
+    unsafe { *(*lmr.as_mut_ptr() as *mut char) = 'e' };
     rdma.write(&lmr, &mut rmr).await.unwrap();
     rdma.send_remote_mr(rmr).await.unwrap();
 }
 
 async fn send_data_to_server(rdma: &Rdma) {
     let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-    unsafe { *(lmr.as_mut_ptr() as *mut char) = 'y' };
+    unsafe { *(*lmr.as_mut_ptr() as *mut char) = 'y' };
     rdma.send(&lmr).await.unwrap();
 }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -17,17 +17,17 @@ async fn read_rmr_from_client(rdma: &Rdma) {
     let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
     let rmr = rdma.receive_remote_mr().await.unwrap();
     rdma.read(&mut lmr, &rmr).await.unwrap();
-    dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+    dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
 }
 
 async fn receive_after_being_written(rdma: &Rdma) {
     let lmr = rdma.receive_local_mr().await.unwrap();
-    dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+    dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
 }
 
 async fn receive_data_from_client(rdma: &Rdma) {
     let lmr = rdma.receive().await.unwrap();
-    dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+    dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
 }
 
 #[tokio::main]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -60,6 +60,7 @@ sudo env "PATH=$PATH" bash -c "
     rustup default $1 && 
     cargo build
     cargo test
+    cargo test --package async-rdma --test cancel_safety --features cancel_safety_test
     cargo run --example rpc
     timeout 3 target/debug/examples/server &
     sleep 1

--- a/src/hashmap_extension.rs
+++ b/src/hashmap_extension.rs
@@ -1,0 +1,83 @@
+use core::hash::Hash;
+use std::collections::{hash_map::Entry, HashMap};
+
+/// `HashMap` extension
+pub(crate) trait HashMapExtension<K: Eq + Hash + Copy, V> {
+    /// Insert the value if the key does not exist in map
+    fn insert_if_not_exists(&mut self, key: K, value: V) -> Option<V>;
+
+    /// Insert value into map until success.
+    ///
+    /// If the key exists in the map, use `key_gen()` to create a new key and return the new key.
+    fn insert_until_success<F: FnOnce() -> K + Copy>(&mut self, value: V, key_gen: F) -> K;
+}
+
+impl<K: Eq + Hash + Copy, V> HashMapExtension<K, V> for HashMap<K, V> {
+    fn insert_if_not_exists(&mut self, key: K, value: V) -> Option<V> {
+        match self.entry(key) {
+            Entry::Occupied(_) => Some(value),
+            Entry::Vacant(vac) => {
+                let _ = vac.insert(value);
+                None
+            }
+        }
+    }
+
+    fn insert_until_success<F: FnOnce() -> K + Copy>(&mut self, value: V, key_gen: F) -> K {
+        let mut key_stub = key_gen();
+        let mut val_stub = value;
+        loop {
+            match self.insert_if_not_exists(key_stub, val_stub) {
+                Some(old_value) => {
+                    val_stub = old_value;
+                    key_stub = key_gen();
+                }
+                None => return key_stub,
+            }
+        }
+    }
+}
+
+#[test]
+fn insert_if_not_exists_test() {
+    let mut contributors = HashMap::from([
+        ("pwang7", 1_i32),
+        ("rogercloud", 2_i32),
+        ("gipsyh", 3_i32),
+        ("Nugine", 4_i32),
+        ("GTwhy", 5_i32),
+    ]);
+    assert!(contributors
+        .insert_if_not_exists("gitter-badger", 6_i32)
+        .is_none());
+    assert_eq!(
+        contributors.insert_if_not_exists("pwang7", 7_i32),
+        Some(7_i32)
+    );
+}
+
+/// Just a key generator simulator
+#[allow(dead_code)] // acturally not dead
+fn key_gen() -> i32 {
+    /// Increase from 0
+    static mut NUM: i32 = 0_i32;
+    unsafe {
+        NUM = NUM.wrapping_add(1_i32);
+        NUM
+    }
+}
+
+#[test]
+fn insert_until_success_test() {
+    let mut contributors = HashMap::from([
+        (1_i32, "pwang7"),
+        (2_i32, "rogercloud"),
+        (3_i32, "gipsyh"),
+        (4_i32, "Nugine"),
+    ]);
+    assert_eq!(contributors.insert_until_success("GTwhy", key_gen), 5_i32);
+    assert_eq!(
+        contributors.insert_until_success("gitter-badger", key_gen),
+        6_i32
+    );
+}

--- a/src/lock_utilities.rs
+++ b/src/lock_utilities.rs
@@ -1,0 +1,200 @@
+use parking_lot::lock_api::{ArcRwLockReadGuard, ArcRwLockWriteGuard, RawRwLock as RawRwLockTrait};
+use parking_lot::{Mutex, MutexGuard, RawRwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::fmt::Debug;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+use crate::memory_region::local::LocalMrInner;
+
+/// Used to transfer rwlock read guard to another type
+pub struct MappedRwLockReadGuard<'a, T> {
+    /// `RawRwLock` reference
+    raw: &'a RawRwLock,
+    /// data with lock
+    data: T,
+}
+
+impl<T: Debug> Debug for MappedRwLockReadGuard<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MappedRwLockReadGuard")
+            .field("data", &&self.data)
+            .finish()
+    }
+}
+
+impl<T> Drop for MappedRwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        // SAFETY: raw lock was locked before this guard
+        unsafe { self.raw.unlock_shared() }
+    }
+}
+
+impl<T> Deref for MappedRwLockReadGuard<'_, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.data
+    }
+}
+
+impl<'a, T> MappedRwLockReadGuard<'a, T> {
+    /// Create a new `MappedRwLockReadGuard` from another `MappedRwLockReadGuard`
+    pub(crate) fn map<F, U>(s: Self, f: F) -> MappedRwLockReadGuard<'a, U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        let raw = s.raw;
+        // SAFETY: copy from the same type
+        let data = unsafe { mem::transmute_copy(&s.data) };
+        #[allow(clippy::mem_forget)] // forget parent guard to avoid double unlock
+        mem::forget(s);
+        let data = f(data);
+        MappedRwLockReadGuard { raw, data }
+    }
+
+    /// Create a new `RwLockReadGuard`
+    pub(crate) fn new<U>(s: RwLockReadGuard<'a, U>, data: T) -> Self {
+        // SAFETY: only one mapped lock guard hold raw lock reference and will unlock
+        // raw lock in the right way when the guard dropped.
+        let raw = unsafe { RwLockReadGuard::rwlock(&s).raw() };
+        #[allow(clippy::mem_forget)] // forget parent guard to avoid double unlock
+        mem::forget(s);
+        MappedRwLockReadGuard { raw, data }
+    }
+}
+
+/// Used to transfer rwlock write guard to another type
+pub struct MappedRwLockWriteGuard<'a, T> {
+    /// `RawRwLock` reference
+    raw: &'a RawRwLock,
+    /// data with lock
+    data: T,
+}
+
+impl<T: Debug> Debug for MappedRwLockWriteGuard<'_, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MappedRwLockWriteGuard")
+            .field("data", &&self.data)
+            .finish()
+    }
+}
+
+impl<T> Drop for MappedRwLockWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        // SAFETY: raw lock was locked before this guard
+        unsafe { self.raw.unlock_exclusive() }
+    }
+}
+
+impl<T> Deref for MappedRwLockWriteGuard<'_, T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for MappedRwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}
+
+impl<'a, T> MappedRwLockWriteGuard<'a, T> {
+    /// Create a new `MappedRwLockWriteGuard` from another `MappedRwLockWriteGuard`
+    pub(crate) fn map<F, U>(s: Self, f: F) -> MappedRwLockWriteGuard<'a, U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        let raw = s.raw;
+        // SAFETY: copy from the same type
+        let data = unsafe { mem::transmute_copy(&s.data) };
+        #[allow(clippy::mem_forget)] // forget parent guard to avoid double unlock
+        mem::forget(s);
+        let data = f(data);
+        MappedRwLockWriteGuard { raw, data }
+    }
+
+    /// Create a new `MappedRwLockWriteGuard`
+    pub(crate) fn new<U>(s: RwLockWriteGuard<'a, U>, data: T) -> Self {
+        // SAFETY: only one mapped lock guard hold raw lock reference and will unlock
+        // raw lock in the right way when the guard dropped.
+        let raw = unsafe { RwLockWriteGuard::rwlock(&s).raw() };
+        #[allow(clippy::mem_forget)] // forget parent guard to avoid double unlock
+        mem::forget(s);
+        MappedRwLockWriteGuard { raw, data }
+    }
+}
+
+/// Insert `ArcRwLockGuard` to a map and remove it when the corresponding
+/// `LocalMrInner`'s RDMA operation is done to ensure that mr will not be misused during ops.
+#[derive(Debug)]
+pub(crate) enum ArcRwLockGuard {
+    /// An RAII rwlock guard returned by the `rwlock.read_arc()`
+    RwLockReadGuard(ArcRwLockReadGuard<RawRwLock, LocalMrInner>),
+    /// An RAII rwlock guard returned by the `rwlock.write_arc()`
+    RwLockWriteGuard(ArcRwLockWriteGuard<RawRwLock, LocalMrInner>),
+}
+
+/// Provides functional expression methods for `Mutex`.
+pub(crate) trait MappedMutex<T> {
+    /// Use `func` to read the value in the mutex
+    fn map_read<F, R>(&self, func: F) -> R
+    where
+        F: FnOnce(&MutexGuard<'_, T>) -> R;
+
+    /// Use `func` to write the value in the mutex
+    fn map_write<F, R>(&self, func: F) -> R
+    where
+        F: FnOnce(&mut MutexGuard<'_, T>) -> R;
+}
+
+impl<T> MappedMutex<T> for Mutex<T> {
+    fn map_read<F, R>(&self, func: F) -> R
+    where
+        F: FnOnce(&MutexGuard<'_, T>) -> R,
+    {
+        let guard = self.lock();
+        func(&guard)
+    }
+
+    fn map_write<F, R>(&self, func: F) -> R
+    where
+        F: FnOnce(&mut MutexGuard<'_, T>) -> R,
+    {
+        let mut guard = self.lock();
+        func(&mut guard)
+    }
+}
+
+#[test]
+fn mapped_read_guard_test() {
+    let lock = parking_lot::RwLock::new(1_i32);
+    let guard = lock.read();
+    assert_eq!(*guard, 1_i32);
+    let mapped_1 = MappedRwLockReadGuard::new(guard, 3_i32);
+    assert!(lock.is_locked());
+    assert_eq!(*mapped_1, 3_i32);
+    let mapped_2 = MappedRwLockReadGuard::map(mapped_1, |num| num + 1_i32);
+    assert!(lock.is_locked());
+    assert_eq!(*mapped_2, 4_i32);
+    drop(mapped_2);
+    assert!(!lock.is_locked());
+}
+
+#[test]
+fn mapped_write_guard_test() {
+    let lock = parking_lot::RwLock::new(1_i32);
+    let mut guard = lock.write();
+    *guard += 1_i32;
+    assert_eq!(*guard, 2_i32);
+    let mut mapped_1 = MappedRwLockWriteGuard::new(guard, 3_i32);
+    *mapped_1 += 1_i32;
+    assert_eq!(*mapped_1, 4_i32);
+    assert!(lock.is_locked_exclusive());
+    let mapped_2 = MappedRwLockWriteGuard::map(mapped_1, |num| num + 1_i32);
+    assert!(lock.is_locked_exclusive());
+    assert_eq!(*mapped_2, 5_i32);
+    drop(mapped_2);
+    assert!(!lock.is_locked_exclusive());
+}

--- a/src/work_request.rs
+++ b/src/work_request.rs
@@ -193,6 +193,6 @@ where
     ibv_sge {
         addr: lmr.addr().cast(),
         length: lmr.length().cast(),
-        lkey: lmr.lkey(),
+        lkey: lmr.lkey_unchecked(),
     }
 }

--- a/tests/cancel_safety.rs
+++ b/tests/cancel_safety.rs
@@ -1,0 +1,34 @@
+use async_rdma::LocalMrReadAccess;
+use async_rdma::LocalMrWriteAccess;
+use async_rdma::Rdma;
+use std::{alloc::Layout, io, time::Duration};
+mod test_utilities;
+use test_utilities::test_server_client;
+
+async fn client(rdma: Rdma) -> io::Result<()> {
+    const LEN: usize = 600 * 1024 * 1024;
+    let mut lmr = rdma.alloc_local_mr(Layout::new::<[u8; LEN]>())?;
+    let mut rmr = rdma
+        .request_remote_mr(Layout::new::<[u8; LEN]>())
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_nanos(100), rdma.write(&lmr, &mut rmr)).await;
+    assert!(!lmr.is_writeable());
+    assert!(lmr.is_readable());
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let _ = tokio::time::timeout(Duration::from_nanos(100), rdma.read(&mut lmr, &rmr)).await;
+    assert!(!lmr.is_writeable());
+    assert!(!lmr.is_readable());
+    rdma.send_remote_mr(rmr).await?;
+    Ok(())
+}
+
+async fn server(rdma: Rdma) -> io::Result<()> {
+    let _lmr = rdma.receive_local_mr().await?;
+    Ok(())
+}
+
+#[test]
+fn main() {
+    test_server_client(server, client);
+}

--- a/tests/imm.rs
+++ b/tests/imm.rs
@@ -12,7 +12,7 @@ mod send_with_imm {
     async fn client(rdma: Rdma) -> io::Result<()> {
         let mut lmr = rdma.alloc_local_mr(Layout::new::<Data>())?;
         // put data into lmr
-        unsafe { std::ptr::write(lmr.as_mut_ptr() as *mut Data, Data(MSG.to_string())) };
+        unsafe { std::ptr::write(*lmr.as_mut_ptr() as *mut Data, Data(MSG.to_string())) };
         // send the content of lmr to server
         rdma.send_with_imm(&lmr, IMM_NUM).await?;
         rdma.send_with_imm(&lmr, IMM_NUM).await?;
@@ -25,18 +25,18 @@ mod send_with_imm {
         // receive the data and imm sent by the client
         let (lmr, imm) = rdma.receive_with_imm().await?;
         assert_eq!(imm, Some(IMM_NUM));
-        unsafe { assert_eq!(MSG.to_string(), *(*(lmr.as_ptr() as *const Data)).0) };
+        unsafe { assert_eq!(MSG.to_string(), *(*(*lmr.as_ptr() as *const Data)).0) };
         // receive the data in mr while avoiding the immediate data is ok.
         let lmr = rdma.receive().await?;
-        unsafe { assert_eq!(MSG.to_string(), *(*(lmr.as_ptr() as *const Data)).0) };
+        unsafe { assert_eq!(MSG.to_string(), *(*(*lmr.as_ptr() as *const Data)).0) };
         // `receive_with_imm` works well even if the client didn't send any immediate data.
         // the imm received will be a `None`.
         let (lmr, imm) = rdma.receive_with_imm().await?;
         assert_eq!(imm, None);
-        unsafe { assert_eq!(MSG.to_string(), *(*(lmr.as_ptr() as *const Data)).0) };
+        unsafe { assert_eq!(MSG.to_string(), *(*(*lmr.as_ptr() as *const Data)).0) };
         // compared to the above, using `receive` is a better choice.
         let lmr = rdma.receive().await?;
-        unsafe { assert_eq!(MSG.to_string(), *(*(lmr.as_ptr() as *const Data)).0) };
+        unsafe { assert_eq!(MSG.to_string(), *(*(*lmr.as_ptr() as *const Data)).0) };
         // wait for the agent thread to send all reponses to the remote.
         tokio::time::sleep(Duration::from_secs(1)).await;
         Ok(())
@@ -57,7 +57,7 @@ mod write_with_imm {
     async fn client(rdma: Rdma) -> io::Result<()> {
         let mut lmr = rdma.alloc_local_mr(Layout::new::<Data>())?;
         let mut rmr = rdma.request_remote_mr(Layout::new::<Data>()).await?;
-        unsafe { std::ptr::write(lmr.as_mut_ptr() as *mut Data, Data(MSG.to_string())) };
+        unsafe { std::ptr::write(*lmr.as_mut_ptr() as *mut Data, Data(MSG.to_string())) };
         // send the content of lmr to server with immediate data.
         rdma.write_with_imm(&lmr, &mut rmr, IMM_NUM).await?;
         // then send this mr to server to make server aware of this mr.
@@ -71,7 +71,7 @@ mod write_with_imm {
         assert_eq!(imm, IMM_NUM);
         let lmr = rdma.receive_local_mr().await?;
         // assert the content of lmr, which was `write` by client
-        unsafe { assert_eq!(MSG.to_string(), *(*(lmr.as_ptr() as *const Data)).0) };
+        unsafe { assert_eq!(MSG.to_string(), *(*(*lmr.as_ptr() as *const Data)).0) };
         // wait for the agent thread to send all reponses to the remote.
         tokio::time::sleep(Duration::from_secs(1)).await;
         Ok(())

--- a/tests/loop.rs
+++ b/tests/loop.rs
@@ -11,7 +11,7 @@ async fn server(rdma: Rdma) -> io::Result<()> {
         let rdma_clone = rdma.clone();
         handles.push(tokio::spawn(async move {
             let lm = rdma_clone.receive().await.unwrap();
-            assert_eq!(unsafe { *(lm.as_ptr() as *mut i32) }, 5);
+            assert_eq!(unsafe { *(*lm.as_ptr() as *mut i32) }, 5);
             assert_eq!(lm.length(), 4);
         }));
     }
@@ -36,7 +36,7 @@ async fn client(rdma: Rdma) -> io::Result<()> {
         tokio::time::sleep(Duration::from_millis(1)).await;
         handles.push(tokio::spawn(async move {
             let lm = rdma_clone.alloc_local_mr(Layout::new::<i32>()).unwrap();
-            unsafe { *(lm.as_ptr() as *mut i32) = 5 };
+            unsafe { *(*lm.as_ptr() as *mut i32) = 5 };
             rdma_clone.send(&lm).await.unwrap();
         }));
     }

--- a/tests/mr_slice.rs
+++ b/tests/mr_slice.rs
@@ -31,7 +31,7 @@ mod local_mr_slice {
         assert_eq!(s4.addr(), lmr.addr() + s4_pos);
         let mut s5 = lmr.get_mut(0..hello.len()).unwrap();
         s5.as_mut_slice().copy_from_slice(hello.as_bytes());
-        assert_eq!(s5.as_slice(), b"hello");
+        assert_eq!(*s5.as_slice(), b"hello");
         Ok(())
     }
 
@@ -147,6 +147,7 @@ mod remote_mr_slice {
 mod remote_mr_slice_overbound {
     use super::*;
     mod test1 {
+
         use super::*;
         async fn server(rdma: Rdma) -> io::Result<()> {
             let lmr = rdma.alloc_local_mr(Layout::new::<[u8; LEN]>()).unwrap();
@@ -155,6 +156,8 @@ mod remote_mr_slice_overbound {
 
         async fn client(rdma: Rdma) -> io::Result<()> {
             let rmr = rdma.receive_remote_mr().await.unwrap();
+            // wait for the agent thread to send all reponses to the remote.
+            tokio::time::sleep(Duration::from_secs(1)).await;
             assert_eq!(rmr.length(), LEN);
             #[allow(clippy::reversed_empty_ranges)]
             let _s1 = rmr.get(2..0).unwrap();
@@ -177,6 +180,8 @@ mod remote_mr_slice_overbound {
 
         async fn client(rdma: Rdma) -> io::Result<()> {
             let rmr = rdma.receive_remote_mr().await.unwrap();
+            // wait for the agent thread to send all reponses to the remote.
+            tokio::time::sleep(Duration::from_secs(1)).await;
             assert_eq!(rmr.length(), LEN);
             let _s1 = rmr.get(0..0).unwrap();
             Ok(())
@@ -198,6 +203,8 @@ mod remote_mr_slice_overbound {
 
         async fn client(rdma: Rdma) -> io::Result<()> {
             let rmr = rdma.receive_remote_mr().await.unwrap();
+            // wait for the agent thread to send all reponses to the remote.
+            tokio::time::sleep(Duration::from_secs(1)).await;
             assert_eq!(rmr.length(), LEN);
             let _s1 = rmr.get(0..LEN + 1).unwrap();
             Ok(())

--- a/tests/rmr_timeout.rs
+++ b/tests/rmr_timeout.rs
@@ -13,13 +13,13 @@ mod send_local_mr {
         sleep(Duration::from_millis(200)).await;
         // timeout, should panic
         rdma.read(&mut lmr, &rmr).await.unwrap();
-        dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+        dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
         Ok(())
     }
 
     async fn client(rdma: Rdma) -> io::Result<()> {
         let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-        unsafe { *(lmr.as_mut_ptr() as *mut char) = 't' };
+        unsafe { *(*lmr.as_mut_ptr() as *mut char) = 't' };
         rdma.send_local_mr_with_timeout(lmr, Duration::from_millis(100))
             .await
             .unwrap();
@@ -38,7 +38,7 @@ mod request_remote_mr {
 
     async fn server(rdma: Rdma) -> io::Result<()> {
         let lmr = rdma.receive_local_mr().await.unwrap();
-        dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+        dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
         Ok(())
     }
 
@@ -48,7 +48,7 @@ mod request_remote_mr {
             .await
             .unwrap();
         let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-        unsafe { *(lmr.as_mut_ptr() as *mut char) = 't' };
+        unsafe { *(*lmr.as_mut_ptr() as *mut char) = 't' };
         sleep(Duration::from_millis(200)).await;
         // timeout, should panic
         rdma.write(&lmr, &mut rmr).await.unwrap();
@@ -69,7 +69,7 @@ mod timeout_check {
 
     async fn server(rdma: Rdma) -> io::Result<()> {
         let lmr = rdma.receive_local_mr().await.unwrap();
-        dbg!(unsafe { *(lmr.as_ptr() as *const char) });
+        dbg!(unsafe { *(*lmr.as_ptr() as *const char) });
         Ok(())
     }
 
@@ -88,7 +88,7 @@ mod timeout_check {
             .await
             .unwrap();
         let mut lmr = rdma.alloc_local_mr(Layout::new::<char>()).unwrap();
-        unsafe { *(lmr.as_mut_ptr() as *mut char) = 't' };
+        unsafe { *(*lmr.as_mut_ptr() as *mut char) = 't' };
         rdma.write(&lmr, &mut rmr).await.unwrap();
         assert!(!rmr.timeout_check());
         rdma.send_remote_mr(rmr).await.unwrap();


### PR DESCRIPTION
Let `event_listener` holds the `Arc`s of the `LocalMrInner`s
that are being used by RDMA ops to ensure cancellation safety.

`LocalMr` was replaced with New struct `LocalMrInner`.
Because every struct that can use APIs should hold an `Arc`
of the mr's metadata, but previous `LocalMr` can't hold itself.

Fixes: #47