### PR TITLE
fix the handling of return values of ibv APIs

### DIFF
--- a/src/error_utilities.rs
+++ b/src/error_utilities.rs
@@ -1,0 +1,25 @@
+use std::io;
+
+use tracing::error;
+
+/// Get the last os error, log with note and return the error
+pub(crate) fn log_ret_last_os_err_with_note(note: &str) -> io::Error {
+    let err = io::Error::last_os_error();
+    if note.is_empty() {
+        error!("OS error {:?}", err);
+    } else {
+        error!("OS error {:?}. Note: {}", err, note);
+    }
+    err
+}
+
+/// Get the last os error, log and return the error
+pub(crate) fn log_ret_last_os_err() -> io::Error {
+    log_ret_last_os_err_with_note("")
+}
+
+/// Get the last os error and just log it
+pub(crate) fn log_last_os_err() {
+    #[allow(clippy::pedantic)] // some errors occur in `drop` methord is not necessary to panic
+    let _ = log_ret_last_os_err_with_note("");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,9 @@ mod agent;
 mod completion_queue;
 /// The rmda device context
 mod context;
+
+/// Error handling utilities
+mod error_utilities;
 /// The event channel that notifies the completion or error of a request
 mod event_channel;
 /// The driver to poll the completion queue

--- a/src/protection_domain.rs
+++ b/src/protection_domain.rs
@@ -1,4 +1,8 @@
-use crate::{context::Context, queue_pair::QueuePairBuilder};
+use crate::{
+    context::Context,
+    error_utilities::{log_last_os_err, log_ret_last_os_err},
+    queue_pair::QueuePairBuilder,
+};
 use rdma_sys::{ibv_alloc_pd, ibv_dealloc_pd, ibv_pd};
 use std::{io, ptr::NonNull, sync::Arc};
 
@@ -20,7 +24,7 @@ impl ProtectionDomain {
     /// Create a protection domain
     pub(crate) fn create(ctx: &Arc<Context>) -> io::Result<Self> {
         let inner_pd =
-            NonNull::new(unsafe { ibv_alloc_pd(ctx.as_ptr()) }).ok_or(io::ErrorKind::Other)?;
+            NonNull::new(unsafe { ibv_alloc_pd(ctx.as_ptr()) }).ok_or_else(log_ret_last_os_err)?;
         Ok(Self {
             ctx: Arc::<Context>::clone(ctx),
             inner_pd,
@@ -36,7 +40,9 @@ impl ProtectionDomain {
 impl Drop for ProtectionDomain {
     fn drop(&mut self) {
         let errno = unsafe { ibv_dealloc_pd(self.as_ptr()) };
-        assert_eq!(errno, 0_i32);
+        if errno != 0_i32 {
+            log_last_os_err();
+        }
     }
 }
 


### PR DESCRIPTION
Most ibv APIs return -1 or NULL on error
and if the call fails, errno will be set to indicate
the reason for the failure.

But there are some places treat the return value as errno.
This commit fixed these wrong handlings and reuse some handling codes.

Fixes: #61