### PR TITLE
correct timer start position

### DIFF
--- a/src/cq_event_listener.rs
+++ b/src/cq_event_listener.rs
@@ -369,6 +369,10 @@ impl ManualTrigger {
     ///         .await
     ///         .unwrap();
     ///
+    ///     let mut lmr = rdma.alloc_local_mr(Layout::new::<[u8; 8]>())?;
+    ///     let _num = lmr.as_mut_slice().write(&[1_u8; 8])?;
+    ///     let instant = Instant::now();
+    ///
     ///     let trigger = rdma.get_manual_trigger().unwrap();
     ///     // polling task
     ///     let _trigger_handle = tokio::spawn(async move {
@@ -378,9 +382,6 @@ impl ManualTrigger {
     ///         }
     ///     });
     ///
-    ///     let mut lmr = rdma.alloc_local_mr(Layout::new::<[u8; 8]>())?;
-    ///     let _num = lmr.as_mut_slice().write(&[1_u8; 8])?;
-    ///     let instant = Instant::now();
     ///     rdma.send(&lmr).await?;
     ///     assert!(instant.elapsed() >= POLLING_INTERVAL);
     ///     Ok(())


### PR DESCRIPTION
The `instant` of recording the time should be performed before the manual polling task is triggered, otherwise the assertion may fail due to insufficient timing.
https://github.com/datenlord/async-rdma/actions/runs/4591687939/jobs/8108065704
