### PR TITLE
feat: RC stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ mod work_request;
 
 use access::flags_into_ibv_access;
 pub use access::AccessFlag;
-use agent::{Agent, RequestSubmitted, MAX_MSG_LEN};
+use agent::{Agent, RequestSubmitted, ResponseKind, MAX_MSG_LEN};
 use clippy_utilities::Cast;
 use completion_queue::{DEFAULT_CQ_SIZE, DEFAULT_MAX_CQE};
 use context::Context;
@@ -184,8 +184,7 @@ pub use mr_allocator::MRManageStrategy;
 use mr_allocator::MrAllocator;
 use protection_domain::ProtectionDomain;
 use queue_pair::{
-    QPSend, QPSendOwn, QueuePair, QueuePairInitAttrBuilder, RQAttr, RQAttrBuilder, SQAttr,
-    SQAttrBuilder,
+    QPSendOwn, QueuePair, QueuePairInitAttrBuilder, RQAttr, RQAttrBuilder, SQAttr, SQAttrBuilder,
 };
 use rdma_sys::ibv_access_flags;
 #[cfg(feature = "cm")]
@@ -196,14 +195,7 @@ use rdma_sys::{
 use rmr_manager::DEFAULT_RMR_TIMEOUT;
 #[cfg(feature = "cm")]
 use std::ptr::null_mut;
-use std::{
-    alloc::Layout,
-    collections::{BTreeMap, VecDeque},
-    fmt::Debug,
-    io,
-    sync::Arc,
-    time::Duration,
-};
+use std::{alloc::Layout, collections::BTreeMap, fmt::Debug, io, sync::Arc, time::Duration};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream, ToSocketAddrs},
@@ -1692,6 +1684,22 @@ impl Rdma {
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Agent is not ready"))?
             .submit_send_data(lm, None)
+            .await
+    }
+
+    /// submit send of the `lm` with imm
+    ///
+    /// Used with `receive_with_imm`.
+    #[inline]
+    async fn submit_send_with_imm(
+        &self,
+        lm: Vec<LocalMr>,
+        imm: u32,
+    ) -> io::Result<RequestSubmitted<QPSendOwn<LocalMr>>> {
+        self.agent
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Agent is not ready"))?
+            .submit_send_data(lm, Some(imm))
             .await
     }
 
@@ -4077,6 +4085,155 @@ impl Rdma {
             .ibv_event_listener()
             .last_event_type()
             .lock())
+    }
+}
+
+/// The wrapper of a RDMA RC connection, with convient methods to write and read.
+/// TODO how to close stream
+#[derive(Debug)]
+pub struct RCStream {
+    /// inner rdma transport
+    inner: Rdma,
+    /// current send sequence number
+    send_seq: u32,
+    /// current recv sequence number
+    recv_seq: u32,
+    /// current lmr to read
+    read_buf: Option<LocalMr>,
+    /// received lmr buffer, rdma will recv data from many AgentThread, which may cause out of order
+    recv_buf: BTreeMap<u32, LocalMr>,
+    /// sender of inflight requests, anthor task will wait for the completion of the request
+    inflights_tx: mpsc::Sender<RequestSubmitted<QPSendOwn<LocalMr>>>,
+}
+
+impl RCStream {
+    /// Create a new RCStream with Rdma
+    pub fn new(inner: Rdma) -> Self {
+        let (inflights_tx, mut inflights_rx) = mpsc::channel(1024);
+        let _ = tokio::spawn(async move {
+            loop {
+                match inflights_rx.recv().await {
+                    Some(inflight) => {
+                        let _ = Self::handle_send_wc(inflight).await;
+                    }
+                    None => {
+                        break;
+                    }
+                }
+            }
+        });
+        RCStream {
+            inner,
+            send_seq: 0,
+            recv_seq: 0,
+            read_buf: None,
+            recv_buf: BTreeMap::new(),
+            inflights_tx,
+        }
+    }
+
+    /// Get the next sequence number, if the current sequence number is u32::MAX, return 0
+    fn next_seq(seq: u32) -> u32 {
+        if seq == u32::MAX {
+            0
+        } else {
+            seq + 1
+        }
+    }
+
+    async fn handle_send_wc(inflight: RequestSubmitted<QPSendOwn<LocalMr>>) -> io::Result<()> {
+        let resp = inflight.response().await?;
+        if let ResponseKind::SendData(send_data_resp) = resp {
+            if send_data_resp.status > 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!(
+                        "send data failed, response status is {}",
+                        send_data_resp.status
+                    ),
+                ));
+            }
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!(
+                    "send data failed, due to unexpected response type {:?}",
+                    resp
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Send a LocalMr to the remote peer.
+    pub async fn send_lmr(&mut self, mut lmr: LocalMr) -> io::Result<()> {
+        while lmr.length() > self.inner.clone_attr.agent_attr.max_message_length {
+            let lmr_segment = lmr.split_to(self.inner.clone_attr.agent_attr.max_message_length);
+
+            let inflight = self
+                .inner
+                .submit_send_with_imm(vec![lmr_segment.unwrap()], self.send_seq)
+                .await?;
+            self.send_seq = Self::next_seq(self.send_seq);
+            match self.inflights_tx.send(inflight).await {
+                Ok(_) => {}
+                Err(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "inflight queue is full",
+                    ))
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// wait for next data lmr
+    async fn read_next_lmr(&mut self) -> io::Result<()> {
+        loop {
+            match self.recv_buf.remove(&self.recv_seq) {
+                Some(lmr) => {
+                    self.read_buf = Some(lmr);
+                    self.recv_seq = Self::next_seq(self.recv_seq);
+                    break;
+                }
+                None => {
+                    let (lmr, seq) = self.inner.receive_with_imm().await?;
+                    match self.recv_buf.insert(seq.unwrap(), lmr) {
+                        Some(_) => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                "recv_buf can not contain duplicated seq",
+                            ))
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// recieve LocalMrs whose total size equal to the given size
+    /// TODO how to read eof?
+    pub async fn recieve_lmr(&mut self, mut fill_size: usize) -> io::Result<Vec<LocalMr>> {
+        let mut ret_lmr = vec![];
+        while fill_size > 0 {
+            if let Some(mut lmr) = self.read_buf.take() {
+                if lmr.length() > fill_size {
+                    let readed = lmr.split_to(fill_size);
+                    self.read_buf = Some(lmr);
+                    ret_lmr.push(readed.unwrap());
+                    fill_size = 0;
+                } else {
+                    fill_size -= lmr.length();
+                    ret_lmr.push(lmr);
+                }
+            } else {
+                self.read_next_lmr().await?;
+            }
+        }
+        Ok(ret_lmr)
     }
 }
 

--- a/src/memory_region/local.rs
+++ b/src/memory_region/local.rs
@@ -527,28 +527,29 @@ impl LocalMr {
     /// # Examples
     ///
     /// ```
-	///     #[tokio::test]
-    ///		async fn test_lmr_split() -> io::Result<()> {
-    /// 		let rdma = RdmaBuilder::default()
-    /// 			.set_port_num(1)
-    /// 			.set_gid_index(1)
-    /// 			.build()?;
-    /// 		let layout = Layout::new::<[u8; 4096]>();
-    /// 		let mut lmr = rdma.alloc_local_mr(layout)?;
-    /// 		let start_addr = lmr.addr();
-    /// 		let lmr_half = lmr.split_to(2048);
-    /// 		assert!(lmr_half.is_some());
-    /// 		let lmr_half = lmr_half.unwrap();
-    /// 		assert_eq!(lmr_half.length(), 2048);
-    /// 		assert_eq!(lmr_half.addr(), start_addr);
-    /// 		let lmr_overbound = lmr.split_to(2049);
-    /// 		assert!(lmr_overbound.is_none());
-	/// 		Ok(())
-	///     }		
+    ///     #[tokio::test]
+    ///     async fn test_lmr_split() -> io::Result<()> {
+    ///         let rdma = RdmaBuilder::default()
+    ///             .set_port_num(1)
+    ///             .set_gid_index(1)
+    ///             .build()?;
+    ///         let layout = Layout::new::<[u8; 4096]>();
+    ///         let mut lmr = rdma.alloc_local_mr(layout)?;
+    ///         let start_addr = lmr.addr();
+    ///         let lmr_half = lmr.split_to(2048);
+    ///         assert!(lmr_half.is_some());
+    ///         let lmr_half = lmr_half.unwrap();
+    ///         assert_eq!(lmr_half.length(), 2048);
+    ///         assert_eq!(lmr_half.addr(), start_addr);
+    ///         let lmr_overbound = lmr.split_to(2049);
+    ///         assert!(lmr_overbound.is_none());
+    ///         Ok(())
+    ///     }
     /// ```
     /// # Panics
     ///
     /// Panics if `at > len`.
+    #[inline]
     pub fn split_to(&mut self, at: usize) -> Option<Self> {
         // SAFETY: `self` is checked to be valid and in bounds above.
         if at > self.length() {

--- a/src/queue_pair.rs
+++ b/src/queue_pair.rs
@@ -1312,6 +1312,7 @@ where
 }
 
 #[derive(Debug)]
+/// Queue pair operation submitted in wq, waitting for wc
 pub(crate) struct QueuePairOpsInflight<Op: QueuePairOp> {
     /// the operation
     op: Op,
@@ -1425,7 +1426,7 @@ impl<Op: QueuePairOp + Unpin> Future for QueuePairOps<Op> {
     }
 }
 
-/// Queue pair operation wrapper, return after libv_post_send
+/// Queue pair operation wrapper, return after `libv_post_send`
 #[derive(Debug)]
 pub(crate) struct QueuePairOpsSubmit<Op: QueuePairOp + Unpin> {
     /// the internal queue pair
@@ -1437,7 +1438,7 @@ pub(crate) struct QueuePairOpsSubmit<Op: QueuePairOp + Unpin> {
 }
 
 impl<Op: QueuePairOp + Unpin> QueuePairOpsSubmit<Op> {
-    /// Create a new queue QueuePairOpsSubmit wrapper
+    /// Create a new queue `QueuePairOpsSubmit` wrapper
     fn new(qp: Arc<QueuePair>, op: Op, inners: LmrInners) -> Self {
         Self {
             qp,


### PR DESCRIPTION
A stream with guaranteed ordering based on send and receive.

- send next packet after previous packet have been submitted in queuepair， anther thread will wait for ack and handle it.

- receive end will stash disordered packet, so user can read  data in order.

