### PR TITLE
fix: add tcache_none for mallocx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   schedule: [cron: "0 */24 * * *"]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.63.0
 
 jobs:
   soft-roce-env:

--- a/examples/cm_client.rs
+++ b/examples/cm_client.rs
@@ -30,7 +30,7 @@ async fn run(node: &str, service: &str) {
         .alloc_local_mr(Layout::new::<[u8; BUF_SIZE]>())
         .unwrap();
     let _ = lmr.as_mut_slice().write(&[BUF_FILLER; BUF_SIZE]).unwrap();
-    let _ = rdma.send_raw(&lmr).await.unwrap();
+    rdma.send_raw(&lmr).await.unwrap();
     println!("send {:?}", *lmr.as_slice());
 
     // recv raw data from server

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -337,21 +337,17 @@ impl AgentThread {
 
     /// The main agent function that handles messages sent from the other side
     async fn main(self: Arc<Self>) -> io::Result<()> {
-        // SAFETY: ?
-        // TODO: check safety
         let mut header_buf = self
             .inner
             .allocator
-            // alignment 1 is always correct
+            // SAFETY: alignment 1 is always correct
             .alloc_zeroed_default(unsafe {
                 &Layout::from_size_align_unchecked(*REQUEST_HEADER_MAX_LEN, 1)
             })?;
-        // SAFETY: ?
-        // TODO: check safety
         let mut data_buf = self
             .inner
             .allocator
-            // alignment 1 is always correct
+            // SAFETY: alignment 1 is always correct
             .alloc_zeroed_default(unsafe {
                 &Layout::from_size_align_unchecked(self.max_sr_data_len, 1)
             })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
     warnings, // treat all wanings as errors
 
     clippy::all,
-    clippy::restriction,
+    // clippy::restriction,
     clippy::pedantic,
     // clippy::nursery, // It's still under development
     clippy::cargo,

--- a/src/mr_allocator.rs
+++ b/src/mr_allocator.rs
@@ -620,7 +620,7 @@ fn remove_item(addr: *mut c_void) {
 #[allow(clippy::as_conversions)]
 #[allow(clippy::unreachable)]
 fn remove_item_after_lock(map: &mut MutexGuard<BTreeMap<usize, Item>>, addr: *mut c_void) {
-    map.remove(&(addr as _)).map_or_else(
+    map.remove(&(addr as usize)).map_or_else(
         || {
             unreachable!(
                 "can not get item from EXTENT_TOKEN_MAP. addr : {}",

--- a/src/work_request.rs
+++ b/src/work_request.rs
@@ -145,7 +145,7 @@ impl AsRef<ibv_send_wr> for SendWr {
     }
 }
 
-impl<'lm> AsMut<ibv_send_wr> for SendWr {
+impl AsMut<ibv_send_wr> for SendWr {
     fn as_mut(&mut self) -> &mut ibv_send_wr {
         &mut self.inner
     }


### PR DESCRIPTION
I have encountered the following problem when spawn multi thread with rdma.

```
 left: `18`,
 right: `17`', /home/wy/rust/async-rdma/src/mr_allocator.rs:443:21
```

it seem that memory allocated by jemalloc does not meet arena requirements(request memory from arena 18, but get memory in arena 17), then the checks of  [lookup_raw_mr](https://github.com/datenlord/async-rdma/blob/033a056fd3304a601d386a56ab5f4b8808c8bd33/src/mr_allocator.rs#L432]  don't pass.

So maybe we should add MALLOCX_TCACHE_NONE flag to disable tcache when using mallocx. (Maybe it is better to set opt.tcache to using mallctl?)

Besides, I add is_write for QueuePairOps, there is no need to acquire write lock of inner for send.